### PR TITLE
Added support for overriding node ID and VSN at runtime.

### DIFF
--- a/vm/Dockerfile
+++ b/vm/Dockerfile
@@ -16,7 +16,6 @@ RUN apt install -y software-properties-common && add-apt-repository --yes --upda
 
 # do not copy "private" folder
 COPY ansible/*.yaml ansible/*.yml ansible/05-sage  /ansible/
-COPY entrypoint.sh .
 
 WORKDIR /ansible
 ENV LC_ALL=C.UTF-8
@@ -51,5 +50,6 @@ RUN ansible-playbook -i localhost, -c local ./waggle_config.yml \
     -e copy_k8s_resource_files=no
     #-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
 
+COPY entrypoint.sh /entrypoint.sh
 CMD /entrypoint.sh
 #CMD /bin/sleep infinity

--- a/vm/entrypoint.sh
+++ b/vm/entrypoint.sh
@@ -6,11 +6,19 @@
 set -x
 set -e
 
+# override node id, if defined
+if [[ "${WAGGLE_NODE_ID}" ]]; then
+  echo "${WAGGLE_NODE_ID}" > /etc/waggle/node-id
+fi
+
+# override node vsn, if defined
+if [[ "${WAGGLE_NODE_VSN}" ]]; then
+  echo "${WAGGLE_NODE_VSN}" > /etc/waggle/vsn
+fi
 
 # create fake kubectl for debugging
 echo -e '#!/bin/bash\necho "(this is a dummy) created"' > /usr/local/bin/kubectl
 chmod +x /usr/local/bin/kubectl
-
 
 cd /etc/waggle
 


### PR DESCRIPTION
This PR introduces the `WAGGLE_NODE_ID` and `WAGGLE_NODE_VSN` environment variables.

If either of these are defined, the entrypoint will override `/etc/waggle/node-id` and `/etc/waggle/vsn` with their values when starting.